### PR TITLE
[codex] Add UserDashboard README Codex status dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# UserDashboard
+
+Vite-powered multi-page frontend for account, billing, plans, docs, downloads, and related user flows.
+
+## Codex Status
+
+| Signal | Current |
+| --- | --- |
+| Template line | `single-repo@1.3.0` |
+| Codexification stage | `operational` |
+| Operational readiness | `passing` |
+| Next target | `maintained` |
+| Conformity | `conforming` |
+| Drift | `overrides` |
+
+```mermaid
+flowchart LR
+  A[Discovered] --> B[Scaffolded] --> C[Standardized] --> D[Operational] --> E[Maintained]
+
+  classDef done fill:#d9f99d,stroke:#3f6212,color:#1a2e05;
+  classDef current fill:#fde68a,stroke:#92400e,color:#451a03,stroke-width:2px;
+  class A,B,C done;
+  class D current;
+```
+
+**Readiness Checks**
+
+| Check | Status |
+| --- | --- |
+| Manifest current | `pass` |
+| Docs current | `pass` |
+| Command inventory grounded | `pass` |
+| Verification path defined | `pass` |
+| Verification path validated | `pass` |
+| Shared skill coverage | `pass` |
+| Repo-local skill coverage | `deferred` |
+| Publish flow current | `pass` |
+| Operational smoke | `pass` |
+
+**Remaining Work**
+
+- Keep the current checks passing.
+- Review future `CodexEnv` upgrades and promote to `maintained` once the repo stays current through a later template review.
+- Resolve or intentionally accept the current build warnings:
+  - `default.css` unresolved at build time
+  - Vite browser-compatibility warning around `node:module`
+
+**Toolkit Available Now**
+
+- Shared Codex metadata:
+  - `AGENTS.md`
+  - `codex-template.json`
+  - `codex-assessment.md`
+- Shared foundation skills:
+  - `env-python-entrypoint`
+  - `env-github-auth`
+  - `git-branch-pr-status`
+  - `git-repo-publish`
+  - `verify-run-local-default`
+- Native repo commands:
+  - `npm install`
+  - `npm run dev`
+  - `npm run build`
+  - `npm run preview`
+
+## Local Development
+
+```bash
+npm install
+npm run dev
+```
+
+The dev server uses port `3000`. Vite proxies `/api` and `/health` to the configured backend target.
+
+## Verification
+
+```bash
+npm run build
+```
+
+Use `npm run preview` when the issue depends on built asset behavior rather than dev-server behavior.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Vite-powered multi-page frontend for account, billing, plans, docs, downloads, a
 
 | Signal | Current |
 | --- | --- |
-| Template line | `single-repo@1.3.0` |
+| Template line | `single-repo@1.4.0` |
 | Codexification stage | `operational` |
 | Operational readiness | `passing` |
 | Next target | `maintained` |
@@ -36,6 +36,7 @@ flowchart LR
 | Repo-local skill coverage | `deferred` |
 | Publish flow current | `pass` |
 | Operational smoke | `pass` |
+| README status surface | `pass` |
 
 **Remaining Work**
 

--- a/codex-assessment.md
+++ b/codex-assessment.md
@@ -8,6 +8,7 @@
 
 ## Assessment Checks
 
+- `readme_status_surface`: `pass`
 - `manifest_current`: `pass`
 - `docs_current`: `pass`
 - `command_inventory_grounded`: `pass`

--- a/codex-template.json
+++ b/codex-template.json
@@ -1,6 +1,6 @@
 {
   "template_type": "single-repo",
-  "template_version": "1.3.0",
+  "template_version": "1.4.0",
   "codexification_stage": "operational",
   "conformity_status": "conforming",
   "template_source": "CodexEnv/templates/single-repo",
@@ -11,6 +11,7 @@
   "next_stage_target": "maintained",
   "operational_readiness": "passing",
   "assessment_checks": {
+    "readme_status_surface": "pass",
     "manifest_current": "pass",
     "docs_current": "pass",
     "command_inventory_grounded": "pass",
@@ -30,5 +31,5 @@
     "Repo-specific command inventory centers on Vite multi-page frontend commands and backend proxy assumptions.",
     "Repo-local skills are still planned rather than implemented, which is acceptable for this frontend repo at the operational stage because the current workflow relies on shared skills plus documented verification commands."
   ],
-  "notes": "UserDashboard is a lightweight frontend codexified from the single-repo@1.3.0 template line using the local CodexEnv checkout as its template source."
+  "notes": "UserDashboard is a lightweight frontend codexified from the single-repo@1.4.0 template line using the local CodexEnv checkout as its template source."
 }


### PR DESCRIPTION
## What changed
- added a README Codex Status dashboard to UserDashboard
- surfaced the current stage, readiness, drift, remaining work, and toolkit in a scan-friendly section
- added a Mermaid stage diagram and readiness score excerpt
- updated the manifest and assessment to include the README status surface check and moved the repo to template line 1.4.0

## Why
The repo already has manifest and assessment detail, but it still takes too much digging to answer basic questions like how codexified it is, what remains to be done, and which toolkit pieces are available right now.

## Validation
- README dashboard content aligned to codex-template.json and codex-assessment.md
- no additional runtime tests were run for this README-only follow-up