### PR TITLE
[codex] Compact the UserDashboard README status card

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,65 +4,13 @@ Vite-powered multi-page frontend for account, billing, plans, docs, downloads, a
 
 ## Codex Status
 
-| Signal | Current |
-| --- | --- |
-| Template line | `single-repo@1.4.0` |
-| Codexification stage | `operational` |
-| Operational readiness | `passing` |
-| Next target | `maintained` |
-| Conformity | `conforming` |
-| Drift | `overrides` |
+`single-repo@1.4.1` • Stage: `operational` • Readiness: `passing` • Next: `maintained`
 
-```mermaid
-flowchart LR
-  A[Discovered] --> B[Scaffolded] --> C[Standardized] --> D[Operational] --> E[Maintained]
+`discovered > scaffolded > standardized > [operational] > maintained`
 
-  classDef done fill:#d9f99d,stroke:#3f6212,color:#1a2e05;
-  classDef current fill:#fde68a,stroke:#92400e,color:#451a03,stroke-width:2px;
-  class A,B,C done;
-  class D current;
-```
+Remaining work: keep the current checks passing, then review the repo on a later `CodexEnv` upgrade to promote it to `maintained`.
 
-**Readiness Checks**
-
-| Check | Status |
-| --- | --- |
-| Manifest current | `pass` |
-| Docs current | `pass` |
-| Command inventory grounded | `pass` |
-| Verification path defined | `pass` |
-| Verification path validated | `pass` |
-| Shared skill coverage | `pass` |
-| Repo-local skill coverage | `deferred` |
-| Publish flow current | `pass` |
-| Operational smoke | `pass` |
-| README status surface | `pass` |
-
-**Remaining Work**
-
-- Keep the current checks passing.
-- Review future `CodexEnv` upgrades and promote to `maintained` once the repo stays current through a later template review.
-- Resolve or intentionally accept the current build warnings:
-  - `default.css` unresolved at build time
-  - Vite browser-compatibility warning around `node:module`
-
-**Toolkit Available Now**
-
-- Shared Codex metadata:
-  - `AGENTS.md`
-  - `codex-template.json`
-  - `codex-assessment.md`
-- Shared foundation skills:
-  - `env-python-entrypoint`
-  - `env-github-auth`
-  - `git-branch-pr-status`
-  - `git-repo-publish`
-  - `verify-run-local-default`
-- Native repo commands:
-  - `npm install`
-  - `npm run dev`
-  - `npm run build`
-  - `npm run preview`
+Toolkit: shared foundation skills plus native verification commands are available now. See `codex-assessment.md`, `skill-inventory.md`, and `command-inventory.md` for detail.
 
 ## Local Development
 

--- a/codex-template.json
+++ b/codex-template.json
@@ -1,6 +1,6 @@
 {
   "template_type": "single-repo",
-  "template_version": "1.4.0",
+  "template_version": "1.4.1",
   "codexification_stage": "operational",
   "conformity_status": "conforming",
   "template_source": "CodexEnv/templates/single-repo",
@@ -31,5 +31,5 @@
     "Repo-specific command inventory centers on Vite multi-page frontend commands and backend proxy assumptions.",
     "Repo-local skills are still planned rather than implemented, which is acceptable for this frontend repo at the operational stage because the current workflow relies on shared skills plus documented verification commands."
   ],
-  "notes": "UserDashboard is a lightweight frontend codexified from the single-repo@1.4.0 template line using the local CodexEnv checkout as its template source."
+  "notes": "UserDashboard is a lightweight frontend codexified from the single-repo@1.4.1 template line using the local CodexEnv checkout as its template source."
 }


### PR DESCRIPTION
## What changed
- reduced the README Codex Status section to a compact top card
- replaced the Mermaid block and large readiness table with a short ASCII stage path and short summary lines
- kept detailed evidence and warnings in codex-assessment.md
- updated the repo manifest from 1.4.0 to 1.4.1 to match the compact status standard

## Why
The previous README dashboard was useful but too visually dominant. This keeps the front-door signal while letting the project README focus on the repo itself.

## Validation
- README content aligned to codex-template.json and codex-assessment.md
- no runtime tests were run for this presentation-only follow-up