### PR TITLE
[codex] Mirror UserDashboard verification in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
-name: Deploy Main to Gh Pages
+name: Verify and Deploy Main to Gh Pages
 
 on:
+  pull_request:
+    branches: [ main ]
   push:
     branches: [ main ]
 
@@ -48,6 +50,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/codex-assessment.md
+++ b/codex-assessment.md
@@ -14,6 +14,7 @@
 - `command_inventory_grounded`: `pass`
 - `verification_path_defined`: `pass`
 - `verification_path_validated`: `pass`
+- `github_actions_verification`: `pass`
 - `shared_skill_coverage`: `pass`
 - `repo_local_skill_coverage`: `deferred`
 - `publish_flow_current`: `pass`
@@ -24,6 +25,7 @@
 - `2026-04-02`: `npm install && npm run build` completed successfully after bootstrapping local dependencies.
 - Build produced output under `dist/` across the documented multi-page entries.
 - `2026-04-02`: explicit Codex workflow smoke pass completed by reading the manifest and assessment, selecting the documented verification path, and successfully running the repo's native verification command without ambiguity.
+- `2026-04-02`: GitHub Actions verification was aligned to the repo's native verification path by running `npm ci` and `npm run build` on pull requests as well as `main` pushes.
 - Warnings remain:
   - `default.css` does not exist at build time and is left unresolved for runtime.
   - Vite reported a browser-compatibility warning related to `node:module` in its bundled module runner.

--- a/codex-template.json
+++ b/codex-template.json
@@ -1,6 +1,6 @@
 {
   "template_type": "single-repo",
-  "template_version": "1.4.1",
+  "template_version": "1.5.0",
   "codexification_stage": "operational",
   "conformity_status": "conforming",
   "template_source": "CodexEnv/templates/single-repo",
@@ -17,6 +17,7 @@
     "command_inventory_grounded": "pass",
     "verification_path_defined": "pass",
     "verification_path_validated": "pass",
+    "github_actions_verification": "pass",
     "shared_skill_coverage": "pass",
     "repo_local_skill_coverage": "deferred",
     "publish_flow_current": "pass",
@@ -31,5 +32,5 @@
     "Repo-specific command inventory centers on Vite multi-page frontend commands and backend proxy assumptions.",
     "Repo-local skills are still planned rather than implemented, which is acceptable for this frontend repo at the operational stage because the current workflow relies on shared skills plus documented verification commands."
   ],
-  "notes": "UserDashboard is a lightweight frontend codexified from the single-repo@1.4.1 template line using the local CodexEnv checkout as its template source."
+  "notes": "UserDashboard is a lightweight frontend codexified from the single-repo@1.5.0 template line using the local CodexEnv checkout as its template source."
 }


### PR DESCRIPTION
## What changed
- updated the GitHub Actions workflow to run the documented verification path on pull requests as well as main pushes
- kept deployment restricted to push events
- updated the codex manifest and assessment to record GitHub Actions verification parity as passing
- bumped the repo template line from 1.4.1 to 1.5.0

## Why
The repo should not rely only on local verification evidence. Its documented Codex verification path should also be enforced in CI whenever the repo changes.

## Validation
- workflow now runs npm ci and npm run build on pull requests and main pushes
- codex assessment updated to reflect CI parity
- no additional local runtime tests were run in this follow-up