### PR TITLE
Disclose trial-to-paid rollover on plans page

### DIFF
--- a/plans.html
+++ b/plans.html
@@ -30,7 +30,9 @@
   </div>
 
   <p class="notice" style="margin-top:18px;">
-    Membership starts in Stripe Checkout. Your account updates after Stripe confirms the subscription.
+    Membership starts in Stripe Checkout. Your free trial converts to a paid monthly
+    membership automatically when it ends &mdash; cancel anytime from Billing.
+    Your account updates after Stripe confirms the subscription.
   </p>
 </main>
 


### PR DESCRIPTION
## Summary
- Plans page now states that the free trial converts to a paid monthly membership automatically when it ends, with cancel-anytime guidance pointing at Billing.
- Copy is deliberately price-agnostic — the amount keeps rendering live from `/api/plans`, so the page can't drift from Stripe.

## Context
Launch pricing went live in Stripe today ($59/mo, `aura_membership_monthly`). Auto-renewal disclosure next to the subscribe button is both good UX and standard compliance practice for trials that roll into paid billing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)