### PR TITLE
Always complete logout locally even if the API call fails

### DIFF
--- a/src/pages/signin.js
+++ b/src/pages/signin.js
@@ -99,6 +99,11 @@ export function initTabs() {
 }
 
 export async function handleLogout() {
-  await api("/api/auth/logout", { method: "POST" });
+  try {
+    await api("/api/auth/logout", { method: "POST" });
+  } catch {
+    // Even if the server call fails (expired session, missing gateway
+    // route, network error), always finish logging out locally.
+  }
   location.href = "index.html";
 }


### PR DESCRIPTION
The logout button appeared dead when `POST /api/auth/logout` failed — the route was missing from the API Gateway route table (now added on both dev and the new staging gateway), and an expired session produced the same stuck behavior. The handler now swallows API errors and always redirects to sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)