### PR TITLE
Pre-checkout charge disclosure + billing support contact

### DIFF
--- a/billing.html
+++ b/billing.html
@@ -31,6 +31,16 @@
   <div class="card" style="padding:18px 22px;">
     <div id="billing-info" class="features">Loading…</div>
   </div>
+
+  <p class="notice" style="margin-top:18px;">
+    Billing questions or need help? Email
+    <a href="mailto:support@auraengine.com">support@auraengine.com</a>. If you believe
+    you were charged in error, contact us before filing a dispute with your bank
+    &mdash; we can review the charge, cancel future billing, and check refund
+    eligibility. Cancelling stops future renewals and takes effect at the end of the
+    current billing period; you keep access until then. Refund and cancellation terms
+    are in our <a href="#" data-legal-view="terms">Terms of Service</a>.
+  </p>
 </main>
 
 <footer class="footer"><span>© 2026 Aura XR Systems LLC</span><span class="mono">BILLING</span></footer>

--- a/plans.html
+++ b/plans.html
@@ -40,6 +40,15 @@
     membership automatically when it ends &mdash; cancel anytime from Billing.
     Your account updates after Stripe confirms the subscription.
   </p>
+
+  <p class="notice" style="margin-top:10px;">
+    Billing questions or need help? Email
+    <a href="mailto:support@auraengine.com">support@auraengine.com</a>. If you believe
+    you were charged in error, contact us before filing a dispute with your bank
+    &mdash; we can review the charge, cancel future billing, and check refund
+    eligibility. Refund and cancellation terms are in our
+    <a href="#" data-legal-view="terms">Terms of Service</a>.
+  </p>
 </main>
 
 <footer class="footer">

--- a/src/pages/plans.js
+++ b/src/pages/plans.js
@@ -32,6 +32,35 @@ function activeBannerHTML(status, subscription) {
     </div>`;
 }
 
+function firstChargeDateLabel(trialDays) {
+  const d = new Date(Date.now() + trialDays * 86400000);
+  return d.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+}
+
+// Card-network + ROSCA rules: the recurring-charge terms must sit directly
+// next to the purchase action, not behind a link or expandable section.
+function chargeDisclosureHTML(plan) {
+  const price = fmtMoney(plan.amountCents, plan.currency);
+  const per = intervalLabel(plan.interval);
+  if (plan.trialDays > 0) {
+    const chargeDate = firstChargeDateLabel(plan.trialDays);
+    return `
+      <div class="charge-disclosure">
+        <strong>${plan.trialDays}-day free trial, then ${price} (USD) / ${per}.</strong>
+        Your card will be charged <strong>${price} on ${chargeDate}</strong> unless you
+        cancel before then. Your membership renews ${per}ly until cancelled — cancel
+        anytime from the <a href="billing.html">Billing</a> page. Cancellation takes
+        effect at the end of the current period, and you keep access until then.
+      </div>`;
+  }
+  return `
+    <div class="charge-disclosure">
+      <strong>${price} (USD) / ${per}, starting today.</strong>
+      Your membership renews ${per}ly until cancelled — cancel anytime from the
+      <a href="billing.html">Billing</a> page.
+    </div>`;
+}
+
 function planCardHTML(plan, memberStatus) {
   const { amountCents, currency, description, interval, name, trialDays } = plan;
   const isMember = hasPlanAccess(memberStatus);
@@ -46,7 +75,8 @@ function planCardHTML(plan, memberStatus) {
   const actions = isMember
     ? `<button class="btn ghost" data-manage-billing>Manage billing</button>
        <a class="btn ghost" href="account.html">View account</a>`
-    : `<button class="btn primary" data-start-membership>Start membership</button>`;
+    : `<button class="btn primary" data-start-membership>${trialDays > 0 ? "Start free trial" : "Start membership"}</button>`;
+  const disclosure = isMember ? "" : chargeDisclosureHTML(plan);
 
   return `
     <div class="card-header">${name}${trialHtml}${currentHtml}</div>
@@ -62,6 +92,7 @@ function planCardHTML(plan, memberStatus) {
           <span class="chip">Client access</span>
           <span class="chip">Billing managed by Stripe</span>
         </div>
+        ${disclosure}
       </div>
       <div class="hr"></div>
       <div class="card-actions">${actions}</div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -427,6 +427,22 @@
 .legal-fineprint{ font-size: 12.5px; color: var(--muted); margin-top: 10px; }
 .legal-fineprint a{ color: var(--accent-2); }
 
+/* Pre-checkout charge disclosure — card networks require these terms to be
+   unmissable next to the purchase action, not behind a link or tooltip. */
+.charge-disclosure{
+  margin: 14px 0 4px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 10px;
+  background: rgba(255,255,255,.03);
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: #d6dee8;
+}
+.charge-disclosure strong{ color: #fff; }
+.charge-disclosure a{ color: var(--accent-2); }
+
 /* Workspace list */
 .ws-list{ display:grid; gap: 10px; }
 .ws-item{


### PR DESCRIPTION
## Why
Visa/Mastercard and ROSCA require the recurring-charge terms to be displayed directly next to the purchase action (not behind a link/tooltip), and a direct customer-service contact to be easy to find before and after purchase.

## What
- **Plans page**: `charge-disclosure` block rendered inside the plan card, directly above the CTA — trial length, post-trial $ price, computed first charge date, renews-monthly-until-cancelled, cancel path and effect. CTA reads **Start free trial** when a trial applies.
- **Plans + Billing pages**: support@auraengine.com contact line with "contact us before disputing with your bank" guidance (chargeback deflection) and a Terms of Service link that opens the in-app legal reader.

Pairs with UserService PR #84 (Stripe Checkout consent text + enrollment confirmation email).

🤖 Generated with [Claude Code](https://claude.com/claude-code)